### PR TITLE
Add Fundstr tier event support

### DIFF
--- a/utils/nostr/nostr-helper-functions.ts
+++ b/utils/nostr/nostr-helper-functions.ts
@@ -8,12 +8,18 @@ import {
 } from "nostr-tools";
 import CryptoJS from "crypto-js";
 import { v4 as uuidv4 } from "uuid";
-import { NostrEvent, ProductFormValues } from "@/utils/types/types";
+import {
+  NostrEvent,
+  ProductFormValues,
+  FundstrTierData,
+} from "@/utils/types/types";
 import { ProductData } from "@/utils/parsers/product-parser-functions";
 import { Proof } from "@cashu/cashu-ts";
 import { NostrSigner } from "@/utils/nostr/signers/nostr-signer";
 import { NostrManager } from "@/utils/nostr/nostr-manager";
 import { removeProductFromCache } from "@/utils/nostr/cache-service";
+
+export const KIND_FUNDSTR_TIER = 30078;
 
 function containsRelay(relays: string[], relay: string): boolean {
   return relays.some((r) => r.includes(relay));
@@ -244,6 +250,37 @@ export async function createNostrShopEvent(
     tags: [],
     created_at: Math.floor(Date.now() / 1000),
     pubkey: pubkey,
+    id: "",
+    sig: "",
+  } as NostrEvent;
+
+  await finalizeAndSendNostrEvent(signer, nostr, msg);
+  return msg;
+}
+
+export async function createFundstrTierEvent(
+  nostr: NostrManager,
+  signer: NostrSigner,
+  pubkey: string,
+  tierData: FundstrTierData
+) {
+  const tags: string[][] = [
+    ["d", tierData.d || uuidv4()],
+    ["title", tierData.title],
+    ["description", tierData.description],
+    ["amount", tierData.amount.toString()],
+    ["currency", tierData.currency],
+    ["recurrence", tierData.recurrence],
+    ["active", tierData.active ? "true" : "false"],
+  ];
+  if (tierData.image) tags.push(["image", tierData.image]);
+
+  const msg = {
+    kind: KIND_FUNDSTR_TIER,
+    content: "",
+    tags,
+    created_at: Math.floor(Date.now() / 1000),
+    pubkey,
     id: "",
     sig: "",
   } as NostrEvent;

--- a/utils/nostr/signers/nostr-nip46-signer.ts
+++ b/utils/nostr/signers/nostr-nip46-signer.ts
@@ -170,7 +170,7 @@ export class NostrNIP46Signer implements NostrSigner {
     args.push(this.bunker.bunkerPubkey);
     args.push(this.bunker.secret || "");
     args.push(
-      "sign_event:0,sign_event:5,sign_event:13,sign_event:1059,sign_event:7375,sign_event:7376,sign_event:10002,sign_event:17375,kind:30019,sign_event:30402,sign_event:30405,sign_event:30406,sign_event:31555,sign_event:31989,sign_event:31990,get_public_key,nip44_encrypt,nip44_decrypt"
+      "sign_event:0,sign_event:5,sign_event:13,sign_event:1059,sign_event:7375,sign_event:7376,sign_event:10002,sign_event:17375,kind:30019,sign_event:30402,sign_event:30405,sign_event:30406,sign_event:30078,sign_event:31555,sign_event:31989,sign_event:31990,get_public_key,nip44_encrypt,nip44_decrypt"
     );
     return await this.sendRPC("connect", args);
   }

--- a/utils/parsers/tier-parser-functions.ts
+++ b/utils/parsers/tier-parser-functions.ts
@@ -1,0 +1,52 @@
+import { NostrEvent, FundstrTierData } from "@/utils/types/types";
+
+export const parseTierEvent = (event: NostrEvent): FundstrTierData => {
+  const parsed: FundstrTierData = {
+    id: event.id,
+    pubkey: event.pubkey,
+    createdAt: event.created_at,
+    d: undefined,
+    title: "",
+    description: "",
+    amount: 0,
+    currency: "",
+    recurrence: "",
+    image: undefined,
+    active: false,
+  };
+
+  const tags = event.tags || [];
+  for (const tag of tags) {
+    const [key, ...values] = tag;
+    switch (key) {
+      case "d":
+        parsed.d = values[0];
+        break;
+      case "title":
+        parsed.title = values[0] || "";
+        break;
+      case "description":
+        parsed.description = values[0] || "";
+        break;
+      case "amount":
+        parsed.amount = Number(values[0]);
+        break;
+      case "currency":
+        parsed.currency = values[0] || "";
+        break;
+      case "recurrence":
+        parsed.recurrence = values[0] || "";
+        break;
+      case "image":
+        parsed.image = values[0];
+        break;
+      case "active":
+        parsed.active = values[0] === "true";
+        break;
+      default:
+        break;
+    }
+  }
+
+  return parsed;
+};

--- a/utils/types/types.ts
+++ b/utils/types/types.ts
@@ -86,6 +86,20 @@ export interface CombinedFormData {
   Required?: string;
 }
 
+export interface FundstrTierData {
+  id: string;
+  pubkey: string;
+  createdAt: number;
+  d?: string;
+  title: string;
+  description: string;
+  amount: number;
+  currency: string;
+  recurrence: string;
+  image?: string;
+  active: boolean;
+}
+
 declare global {
   interface Window {
     webln: any;


### PR DESCRIPTION
## Summary
- define `FundstrTierData` interface
- add `KIND_FUNDSTR_TIER` constant
- support creation of tier events in nostr helper
- allow signing tier events with nip46 signer
- provide parser for tier events

## Testing
- `npm run lint-all` *(fails: Cannot find module 'nostr-tools')*